### PR TITLE
docs: add imagemagick install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ pip3 install selenium
 wget https://github.com/mozilla/geckodriver/releases/download/v0.31.0/geckodriver-v0.31.0-linux64.tar.gz
 tar xzvf geckodriver-v0.31.0-linux64.tar.gz
 sudo mv geckodriver /usr/local/bin/
+
+sudo apt install -y imagemagick
 ```
 
 ## FAQ and Troubleshooting


### PR DESCRIPTION
Signed-off-by: hsgwa <19860128+hsgwa@users.noreply.github.com>

To use `convert` command, caret_report requires imagemagick.
This PR adds installation command for imagemagick.