### PR TITLE
ci(workaround): fix cannot import name 'url_quote' from 'werkzeug.urls'

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,7 @@ RUN wget -nv "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux6
     ln -s /opt/firefox/firefox /usr/local/bin/firefox
 
 RUN pip3 install --no-cache-dir Flask==2.1.0 selenium==4.4.3 pandas==1.5.0 bokeh==2.4.1 pandas-bokeh==0.5.5
+RUN pip3 install --no-cache-dir werkzeug==2.3.7  # workaround (https://github.com/Azure-Samples/azure-search-openai-demo/issues/694)
 
 RUN wget -nv https://github.com/mozilla/geckodriver/releases/download/v0.31.0/geckodriver-v0.31.0-linux64.tar.gz && \
     tar xzvf geckodriver-v0.31.0-linux64.tar.gz && \


### PR DESCRIPTION
This PR fixes `fix cannot import name 'url_quote' from 'werkzeug.urls' ` error when importing Flask.
Reference: https://github.com/Azure-Samples/azure-search-openai-demo/issues/694