### PR TITLE
feat: display additinal information

### DIFF
--- a/report/analyze_node/analyze_node.py
+++ b/report/analyze_node/analyze_node.py
@@ -88,6 +88,7 @@ class StatsNode():
                      callback_stats: StatsCallback):
         self.callbacks.setdefault(callback.callback_name, {})
         self.callbacks[callback.callback_name]['callback_legend'] = callback_legend
+        self.callbacks[callback.callback_name]['callback_symbol'] = callback.symbol
         self.callbacks[callback.callback_name]['callback_type'] = callback.callback_type.type_name
         self.callbacks[callback.callback_name]['period_ns'] = callback.timer.period_ns if callback.callback_type == CallbackType.TIMER else -1
         self.callbacks[callback.callback_name]['subscribe_topic_name'] = callback.subscribe_topic_name if callback.callback_type == CallbackType.SUBSCRIPTION else ''

--- a/report/analyze_node/template_node_detail.html
+++ b/report/analyze_node/template_node_detail.html
@@ -42,7 +42,7 @@
           </tr>
           {% for callback_name, callback_stats in node_info['callbacks'].items() %}
             {% if callback_stats[metrics] %}
-              <tr>
+              <tr title="{{ callback_stats['callback_symbol'] }}">
                 <td>{{ callback_stats['callback_legend'] }}</td>
                 {% if callback_stats['period_ns'] != -1 %}
                     <td>{{ callback_stats['period_ns'] / 1e6 }} [ms]</td>

--- a/report/analyze_path/template_path_detail.html
+++ b/report/analyze_path/template_path_detail.html
@@ -112,6 +112,39 @@
         </div>
       </div>
 
+
+      <h4>Response Time Details</h4>
+      <div>
+        <table class="table table-hover table-bordered" style="word-break: break-word">
+          <thead>
+            <tr class="table-primary text-center">
+              <th>Latency in Node / Topic </th>
+              <th>Avg [ms]</th>
+              <th>Median [ms]</th>
+              <th>Min [ms]</th>
+              <th>95%ile [ms]</th>
+              <th>99%ile [ms]</th>
+              <th>Max [ms]</th>
+              <th>Std [ms]</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for name, stats_value in path_info.stacked_bar_best.items() %}
+            <tr>
+              <td>{{ name}} </td>
+              <td class="text-end">{{ '%0.3f' % stats_value.avg|float }}</td>
+              <td class="text-end">{{ '%0.3f' % stats_value.p50|float }}</td>
+              <td class="text-end">{{ '%0.3f' % stats_value.min|float }}</td>
+              <td class="text-end">{{ '%0.3f' % stats_value.p95|float }}</td>
+              <td class="text-end">{{ '%0.3f' % stats_value.p99|float }}</td>
+              <td class="text-end">{{ '%0.3f' % stats_value.max|float }}</td>
+              <td class="text-end">{{ '%0.3f' % stats_value.std|float }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
       <div>
         {% set height_stacked_bar_graph = path_info.node_names|length * 2 * 30 + 400 %}
         {% if display_worst == true %}

--- a/report/validate_callback/template_callback_detail.html
+++ b/report/validate_callback/template_callback_detail.html
@@ -47,7 +47,7 @@
             {% else %}
               {% continue %}
             {% endif %}
-            <tr>
+            <tr title="{{ stats['stats']['callback_symbol'] }}">
               <td>{{ stats['stats']['callback_legend'] }}</td>
               <td>
                 {% if stats['stats']['period_ns'] != -1 %}

--- a/report/validate_callback/template_callback_metrics.html
+++ b/report/validate_callback/template_callback_metrics.html
@@ -56,7 +56,11 @@
         {% set ns = namespace(index = 0) %}
         {% for node_name, stats_callback_metrics in stats_node_callback_metrics.items() %}
           {% for callback_name, stats_metrics in stats_callback_metrics.items() %}
+          {% if metrics_name in stats_metrics %}
+          <tr title="{{ stats_metrics[metrics_name]['stats']['callback_symbol'] }}">
+          {% else %}
           <tr>
+          {% endif %}
             <td>{{ ns.index }}</td>
             {% set ns.index = ns.index + 1 %}
             <td><a href="{{ node_filename_dict[node_name] }}">{{ node_name | safe }}</a></td>
@@ -64,7 +68,7 @@
             {% for i in range(10) %}
               <td>---</td>
             {% endfor %}
-            </tr>
+          </tr>
             {% continue %}
             {% endif %}
             {% set stats = stats_metrics[metrics_name] %}

--- a/report/validate_callback/template_callback_validation.html
+++ b/report/validate_callback/template_callback_validation.html
@@ -54,7 +54,7 @@
         {% set ns = namespace(index = 0) %}
         {% for node_name, stats_callback_metrics in stats_node_callback_metrics.items() %}
           {% for callback_name, stats_metrics in stats_callback_metrics.items() %}
-          <tr>
+          <tr title="{{ stats_metrics[stats_metrics | first]['stats']['callback_symbol'] }}">
             <td>{{ ns.index }}</td>
             {% set ns.index = ns.index + 1 %}
             <td><a href="{{ node_filename_dict[node_name] }}">{{ node_name | safe }}</a></td>

--- a/report/validate_callback/validate_callback.py
+++ b/report/validate_callback/validate_callback.py
@@ -126,6 +126,7 @@ class Stats():
         self.component_name = ''
         self.node_name = ''
         self.callback_name = ''
+        self.callback_symbol = ''
         self.callback_type = ''
         self.period_ns = ''
         self.subscribe_topic_name = ''
@@ -146,6 +147,7 @@ class Stats():
         stats.component_name = component_name
         stats.node_name = node_name
         stats.callback_name = callback.callback_name
+        stats.callback_symbol = callback.symbol
         stats.callback_type = callback.callback_type.type_name
         stats.period_ns = callback.timer.period_ns if callback.callback_type == CallbackType.TIMER else -1
         stats.subscribe_topic_name = callback.subscribe_topic_name if callback.callback_type == CallbackType.SUBSCRIPTION else ''


### PR DESCRIPTION
# Why this PR is needed

- 1. Current path analysis report shows a stacked bar graph so that a user can see the breakdown of response time. However, it's hard to figure out over view at a glance using the stacked bar graph
- 2. Current node analysis report uses timer period for timer callbacks and topic name for subscription callbacks. In case a node has several timer callbacks with the same period, it's difficult to distinguish them

# What this PR changes

- 1. Display the stats of the breakdown of response time
- 2. Add hint for callback. When mouse hovered, symbol name will be displayed

![image](https://github.com/tier4/caret_report/assets/11009876/83c94585-c325-41a1-aadf-c2294101fb4a)

![image](https://github.com/tier4/caret_report/assets/11009876/3ea0e8f4-1cc4-4536-b0ca-61259020e380)

