### PR TITLE
fix: apply strip time to valid_duration

### DIFF
--- a/report/report_analysis/analyze_all.py
+++ b/report/report_analysis/analyze_all.py
@@ -97,7 +97,8 @@ def main():
 
     # Read trace data
     trace_data = args.trace_data if args.sub_trace_data == '' else [args.trace_data, args.sub_trace_data]
-    lttng = read_trace_data(trace_data, args.start_strip, args.end_strip, False)
+    start_strip, end_strip = (0, 0) if args.find_valid_duration else (args.start_strip, args.end_strip )
+    lttng = read_trace_data(trace_data, start_strip, end_strip, False)
     arch = Architecture('lttng', trace_data)
 
     # Create architecture for path analysis
@@ -107,9 +108,9 @@ def main():
     # Find duration to be analyzed
     #  Run path analysis and find start point(sec) where the topic runs in the paths
     if args.find_valid_duration:
-        start_strip, end_strip = find_valid_duration.analyze(args, lttng, arch_path, app)
-        args.start_strip = start_strip
-        args.end_strip = end_strip
+        valid_start, valid_end = find_valid_duration.analyze(args, lttng, arch_path, app)
+        args.start_strip = valid_start + args.start_strip
+        args.end_strip = valid_end + args.end_strip
         logger.info(f'Find valid duration. start_strip: {args.start_strip}, end_strip: {args.end_strip}')
         logger.info(f'Reload trace data')
         lttng = read_trace_data(trace_data, args.start_strip, args.end_strip, False)

--- a/report/report_validation/validate_all.py
+++ b/report/report_validation/validate_all.py
@@ -109,7 +109,8 @@ def main():
 
     # Read trace data
     trace_data = args.trace_data if args.sub_trace_data == '' else [args.trace_data, args.sub_trace_data]
-    lttng = read_trace_data(trace_data, args.start_strip, args.end_strip, False)
+    start_strip, end_strip = (0, 0) if args.find_valid_duration else (args.start_strip, args.end_strip )
+    lttng = read_trace_data(trace_data, start_strip, end_strip, False)
     arch = Architecture('lttng', trace_data)
 
     # Create architecture for path analysis
@@ -119,9 +120,9 @@ def main():
     # Find duration to be analyzed
     #  Run path analysis and find start point(sec) where the topic runs in the paths
     if args.find_valid_duration:
-        start_strip, end_strip = find_valid_duration.analyze(args, lttng, arch_path, app)
-        args.start_strip = start_strip
-        args.end_strip = end_strip
+        valid_start, valid_end = find_valid_duration.analyze(args, lttng, arch_path, app)
+        args.start_strip = valid_start + args.start_strip
+        args.end_strip = valid_end + args.end_strip
         logger.info(f'Find valid duration. start_strip: {args.start_strip}, end_strip: {args.end_strip}')
         logger.info(f'Reload trace data')
         lttng = read_trace_data(trace_data, args.start_strip, args.end_strip, False)


### PR DESCRIPTION
# Issues to be fixed

When find_valid_duration is true, start_strip and end_strip is automatically set. However, a user may want to add extra strip time

# Test performed

### find_valid_duration=false, start_strip=0
![image](https://github.com/user-attachments/assets/48b4052c-a9e3-4b62-b911-49a393c4dc5f)

### find_valid_duration=true, start_strip=0
![image](https://github.com/user-attachments/assets/75f9e8bf-a8c2-43e8-9686-c22fa3683073)

### find_valid_duration=true, start_strip=10 (before)
10 of start_strip is ignored
![image](https://github.com/user-attachments/assets/fd72cb27-9366-4260-99c2-68f101f5d972)

### find_valid_duration=true, start_strip=10 (after)
10 of start_strip is added
![image](https://github.com/user-attachments/assets/3b08a5a9-fb46-464e-80f8-9eaeb94814c2)



