### PR TITLE
feat: enable callback upper limit validation

### DIFF
--- a/report/validate_callback/validate_callback.py
+++ b/report/validate_callback/validate_callback.py
@@ -112,7 +112,7 @@ class Expectation():
 
     @staticmethod
     def read_frequency_expectations(expectation_csv_filename: str, component_name: Optional[str],
-                                    lower_limit_scale=0.8, upper_limit_scale=1.2, ratio=0.2, burst_num=5) -> List:
+                                    lower_limit_scale=0.8, ratio=0.2, burst_num=5) -> List:
         expectation_csv_rows = Expectation._read_expectation_csv(expectation_csv_filename)
         expectation_list: list[Expectation] = []
         for row in expectation_csv_rows:
@@ -123,7 +123,7 @@ class Expectation():
                     continue
                 value = row['value']
                 lower_limit_value = value * lower_limit_scale
-                upper_limit_value = value * upper_limit_scale
+                upper_limit_value = float('inf')
 
                 if row['callback_type'] == 'timer_callback':
                     expectation = Expectation(
@@ -245,8 +245,8 @@ class Result():
             self.ratio_upper_limit = float((df_callback > expectation.upper_limit).sum() / len(df_callback))
             if self.ratio_lower_limit > expectation.ratio:
                 self.result_ratio_lower_limit = ResultStatus.FAILED.name
-            # if self.ratio_upper_limit > expectation.ratio:
-            #     self.result_ratio_upper_limit = ResultStatus.FAILED.name
+            if self.ratio_upper_limit > expectation.ratio:
+                self.result_ratio_upper_limit = ResultStatus.FAILED.name
 
             flag_group = [(flag, len(list(group))) for flag, group in groupby(df_callback, key=lambda x: x < expectation.lower_limit)]
             group = [x[1] for x in flag_group if x[0]]
@@ -256,8 +256,8 @@ class Result():
             self.burst_num_upper_limit = max(group) if len(group) > 0 else 0
             if self.burst_num_lower_limit > expectation.burst_num:
                 self.result_burst_num_lower_limit = ResultStatus.FAILED.name
-            # if self.burst_num_upper_limit > expectation.burst_num:
-            #     self.result_burst_num_upper_limit = ResultStatus.FAILED.name
+            if self.burst_num_upper_limit > expectation.burst_num:
+                self.result_burst_num_upper_limit = ResultStatus.FAILED.name
 
         if self.result_ratio_lower_limit == ResultStatus.FAILED.name or \
            self.result_ratio_upper_limit == ResultStatus.FAILED.name or \

--- a/report/validate_callback/validate_callback.py
+++ b/report/validate_callback/validate_callback.py
@@ -60,8 +60,8 @@ class Expectation():
     id = 0
 
     def __init__(self, component_name: str, node_name: str, callback_name: str, callback_type: CallbackType,
-                 period_ns: Optional[int], topic_name: Optional[str], value: float, lower_limit: Optional[float] = None,
-                 upper_limit: Optional[float] = None, ratio: Optional[float] = None, burst_num: Optional[int] = None):
+                 period_ns: Optional[int], topic_name: Optional[str], value: float, lower_limit: float, upper_limit: float,
+                 ratio: Optional[float] = None, burst_num: Optional[int] = None):
         if callback_type == CallbackType.TIMER and period_ns is not None:
             pass
         elif callback_type == CallbackType.SUBSCRIPTION and topic_name is not None:
@@ -78,8 +78,8 @@ class Expectation():
         self.period_ns = period_ns
         self.topic_name = topic_name
         self.value = value
-        self.lower_limit = lower_limit or self.value * 0.8
-        self.upper_limit = upper_limit or self.value * 1.2
+        self.lower_limit = lower_limit
+        self.upper_limit = upper_limit
         self.ratio = ratio or 0.2
         self.burst_num = burst_num or 5
 


### PR DESCRIPTION
## Change
- Refactoring on the function that read expectation value from csv file.
- Enable upper limit validation
  - And set frequency upper validation value infinity

## Test
Regression test was executed and passed.
https://github.com/tier4/caret_report/actions/runs/14031737794

## Note
These change is preparation for adding latency validation.
Almost change is related to refactoring, so please see following commit.
https://github.com/tier4/caret_report/commit/23cd576e59c4466fa8f573ab86c24fa3b692ecfb
https://github.com/tier4/caret_report/commit/9ac4717cbed9911b7776f6da386d2f45a22a3c0d