### PR TITLE
feat: update run.sh to accept trace data path as an argument

### DIFF
--- a/sample_autoware/README.md
+++ b/sample_autoware/README.md
@@ -123,11 +123,10 @@ ros2 caret check_ctf ~/.ros/tracing/session_yyyymmddhhmmss
 ```sh
 source ${caret_dir}/install/local_setup.bash
 cd ${path-to-this-repo}/sample_autoware
-sh ./run.sh
+sh ./run.sh ~/.ros/tracing/session_yyyymmddhhmmss
 ```
 
 - Before running the script, please modify the settings in `sample_autoware/run.sh`
-  - `trace_data`: Set path to trace data
   - `target_path_json`: Use `./target_path_latest.json` if you runs the latest Autoware or modify the json file
   - Setting files in this directory are just a sample, and may not work with your trace data.
     - Please modify them for your case. ([Explanation](../report/README.md))

--- a/sample_autoware/run.sh
+++ b/sample_autoware/run.sh
@@ -19,7 +19,16 @@ export is_html_only=false
 export find_valid_duration=false
 export duration=0
 
-export trace_data=~/work/caret_tracedata/universe/session-20231114050140/session-20231114050140
+if [ $# -lt 1 ]; then
+  echo "Error: Please specify the path to trace_data (cf: ~/.ros/tracing/session-ooo) as an argument."
+  echo "Usage: $0 <trace_data_path> [sub_trace_data_path:optional]"
+  exit 1
+fi
+
+export trace_data=$1
+if [ $# -ge 2 ]; then
+  export sub_trace_data=$2
+fi
 
 # Create analysis report
 sh ../report/report_analysis/make_report.sh

--- a/sample_autoware/run.sh
+++ b/sample_autoware/run.sh
@@ -20,14 +20,14 @@ export find_valid_duration=false
 export duration=0
 
 if [ $# -lt 1 ]; then
-  echo "Error: Please specify the path to trace_data (cf: ~/.ros/tracing/session-ooo) as an argument."
-  echo "Usage: $0 <trace_data_path> [sub_trace_data_path:optional]"
-  exit 1
+    echo "Error: Please specify the path to trace_data (cf: ~/.ros/tracing/session-ooo) as an argument."
+    echo "Usage: $0 <trace_data_path> [sub_trace_data_path:optional]"
+    exit 1
 fi
 
 export trace_data=$1
 if [ $# -ge 2 ]; then
-  export sub_trace_data=$2
+    export sub_trace_data=$2
 fi
 
 # Create analysis report


### PR DESCRIPTION
# Background
Trace data is created in directories named `session_yyyymmddhhmmss`. This means the trace_data path in `run.sh` has to be updated every time you want to create a report. It would be useful if the trace_data path could be set via a script argument.

# Changes
Added argument to run.sh

# Testing
**Terminal output without argument**
```
~/caret_report_pilot_auto/caret_report/sample_autoware$ ./run.sh 
Error: Please specify the path to trace_data (cf: ~/.ros/tracing/session-ooo) as an argument.
Usage: ./run.sh <trace_data_path> [sub_trace_data_path:optional]
```

**Terminal output with argument**
```
~/caret_report_pilot_auto/caret_report/sample_autoware$ source ~/caret_ws/ros2_caret_ws/install/setup.bash 
~/caret_report_pilot_auto/caret_report/sample_autoware$ ./run.sh ~/.ros/tracing/session-20250512135732
Succeed to find record_cpp_impl. the C++ version will be used.
WARNING : 2025-05-22 17:52:54 | Failed to load log config.
WARNING : 2025-05-22 17:52:54 | Unable to configure handler 'file_handler'
          :
<<< OK. report page is created >>>
<<< OK. All report pages are created >>>

~/caret_report_pilot_auto/caret_report/sample_autoware$ ls output/
report_session-20250512135732  val_session-20250512135732
```