### PR TITLE
feat: save temp file into output dir

### DIFF
--- a/report/analyze_path/analyze_path.py
+++ b/report/analyze_path/analyze_path.py
@@ -271,7 +271,6 @@ def analyze(args, lttng: Lttng, arch: Architecture, app: Application, dest_dir: 
     _logger.info('<<< Analyze Paths: Start >>>')
     xaxis_type =  'sim_time' if args.sim_time else 'system_time'
     make_destination_dir(dest_dir, args.force, _logger)
-    shutil.copy(args.architecture_file_path, dest_dir)
 
     include_first_last_callback = get_include_first_last_callback(args, arch)
 

--- a/report/report_analysis/analyze_all.py
+++ b/report/report_analysis/analyze_all.py
@@ -84,6 +84,8 @@ def main():
     logger.debug(f'sim_time: {args.sim_time}')
     logger.debug(f'is_path_analysis_only: {args.is_path_analysis_only}')
     logger.debug(f'target_path_json: {args.target_path_json}')
+    if not os.path.isabs(args.architecture_file_path):
+        args.architecture_file_path = os.path.join(args.dest_dir, args.architecture_file_path)
     logger.debug(f'architecture_file_path: {args.architecture_file_path}')
     logger.debug(f'use_latest_message: {args.use_latest_message}')
     logger.debug(f'max_node_depth: {args.max_node_depth}')

--- a/report/report_analysis/make_report.sh
+++ b/report/report_analysis/make_report.sh
@@ -41,7 +41,6 @@ if ${use_python}; then
             --end_strip "${end_strip}" \
             --sim_time "${sim_time}" \
             --target_path_json="${target_path_json}" \
-            --architecture_file_path=architecture_path.yaml \
             --max_node_depth="${max_node_depth}" \
             --timeout="${timeout}" \
             --find_valid_duration="${find_valid_duration}" \

--- a/report/report_validation/make_report.sh
+++ b/report/report_validation/make_report.sh
@@ -42,7 +42,6 @@ if ${use_python}; then
             --end_strip "${end_strip}" \
             --sim_time "${sim_time}" \
             --target_path_json="${target_path_json}" \
-            --architecture_file_path=architecture_path.yaml \
             --max_node_depth="${max_node_depth}" \
             --timeout="${timeout}" \
             --find_valid_duration="${find_valid_duration}" \

--- a/report/report_validation/validate_all.py
+++ b/report/report_validation/validate_all.py
@@ -91,6 +91,8 @@ def main():
     logger.debug(f'sim_time: {args.sim_time}')
     logger.debug(f'is_path_analysis_only: {args.is_path_analysis_only}')
     logger.debug(f'target_path_json: {args.target_path_json}')
+    if not os.path.isabs(args.architecture_file_path):
+        args.architecture_file_path = os.path.join(args.dest_dir, args.architecture_file_path)
     logger.debug(f'architecture_file_path: {args.architecture_file_path}')
     logger.debug(f'use_latest_message: {args.use_latest_message}')
     logger.debug(f'max_node_depth: {args.max_node_depth}')


### PR DESCRIPTION
## Background
- Before this PR, `architecture_path.yaml` is saved in the work directory (e.g. `sample_autoware/architecture_path.yaml` , then the yaml file is copied to the output directory
- This prevents users from running multiple report generations in the same directory because `architecture_path.yaml` might be modified by another report generation process

## Changes
- Save `architecture_path.yaml` into `{dest_dir}/architecture_path.yaml` 

## Tests

### Before this PR

```
caret_report/sample_autoware$ ls
architecture_path.yaml  caret.log                component_list.json   note_text_top.txt  README.md  target_path.json
callback_list.csv       caret_topic_filter.bash  note_text_bottom.txt  output             run.sh

## ↑architecture_path.yaml has been generated in the work directory
```


### After this PR
```
caret_report/sample_autoware$ ls
callback_list.csv  caret_topic_filter.bash  note_text_bottom.txt  output     run.sh
caret.log          component_list.json      note_text_top.txt     README.md  target_path.json

## ↑No temporary files have been generated (except for caret.log but it's not a big problem)

caret_report/sample_autoware$ ls output/report_session-20250228193804/
analyze_node  analyze_path  architecture_path.yaml  component_list.json  target_path.json

## ↑Instead, architecture_path.yaml is generated in the report output dir
```