### PR TITLE
fix: fix indentation of _logger.info in remove_duplicate_subscriptions

### DIFF
--- a/report/analyze_path/add_path_to_architecture.py
+++ b/report/analyze_path/add_path_to_architecture.py
@@ -281,7 +281,7 @@ def remove_duplicate_subscriptions(architecture_file_path: str):
     with open(architecture_file_path, 'w', encoding='UTF-8') as f:
         yaml.dump(yml, f, encoding='utf-8', allow_unicode=True, sort_keys=False)
 
-_logger.info('remove_duplicate_subscriptions: cleaned up %s', duplicated_topics_by_node.keys())
+    _logger.info('remove_duplicate_subscriptions: cleaned up %s', duplicated_topics_by_node.keys())
 
 def convert_context_type_to_use_latest_message(arch: Architecture):
     """Convert context_type from UNDEFINED to use_latest_message"""


### PR DESCRIPTION
## Summary
- The `_logger.info(...)` call at the end of `remove_duplicate_subscriptions` was missing indentation, placing it at module level instead of inside the function
- This causes `AttributeError: 'NoneType' object has no attribute 'info'` on import because `_logger` is not yet initialized at module load time
- Introduced in #206

## Test plan
- [x] Verify that `run.sh` completes report generation without errors