### PR TITLE
fix: use separate arch instances for path and non-path analyses

### DIFF
--- a/report/analyze_node/analyze_node.py
+++ b/report/analyze_node/analyze_node.py
@@ -206,7 +206,6 @@ def analyze(args, lttng: Lttng, arch: Architecture, app: Application, dest_dir: 
         _logger = create_logger(__name__, logging.DEBUG if args.verbose else logging.INFO)
     _logger.info('<<< Analyze Nodes: Start >>>')
     make_destination_dir(dest_dir, args.force, _logger)
-    arch.export(dest_dir + '/architecture.yaml', force=True)
     ComponentManager().initialize(args.component_list_json, _logger)
 
     for component_name, _ in ComponentManager().component_dict.items():

--- a/report/analyze_path/analyze_path.py
+++ b/report/analyze_path/analyze_path.py
@@ -277,13 +277,18 @@ def analyze(args, lttng: Lttng, arch: Architecture, app: Application, dest_dir: 
     stats_list = []
 
     # Verify each path
+    invalid_path_names = []
     for target_path in arch.paths:
         target_path_name = target_path.path_name
         path = arch.get_path(target_path_name)
         ret_verify = path.verify()
         _logger.info(f'path.verify {target_path_name}: {ret_verify}')
         if not ret_verify:
-            sys.exit(-1)
+            invalid_path_names.append(target_path_name)
+
+    for path_name in invalid_path_names:
+        _logger.warning(f'path has been removed {path_name}')
+        arch.remove_path(path_name)
 
     # Analyze each path
     for target_path in arch.paths:

--- a/report/analyze_path/analyze_path.py
+++ b/report/analyze_path/analyze_path.py
@@ -159,11 +159,11 @@ def check_the_first_last_callback_is_valid(records: RecordsInterface):
     df_records = records.to_dataframe()
     is_first_valid = True
     is_last_valid = True
-    if len(df_records[df_records.columns[0]]) == 0:
+    if len(df_records.columns) == 0 or len(df_records[df_records.columns[0]]) == 0:
         # velodyne_convert_node doesn't have the first callback_start
         _logger.warning(f'  The first callback is invalid')
         is_first_valid = False
-    if len(df_records[df_records.columns[-1]]) == 0:
+    if len(df_records.columns) == 0 or len(df_records[df_records.columns[-1]]) == 0:
         _logger.warning(f'  The last callback is invalid')
         is_last_valid = False
     return is_first_valid, is_last_valid

--- a/report/analyze_topic/analyze_topic.py
+++ b/report/analyze_topic/analyze_topic.py
@@ -195,7 +195,6 @@ def analyze(args, lttng: Lttng, arch: Architecture, app: Application, dest_dir: 
         _logger = create_logger(__name__, logging.DEBUG if args.verbose else logging.INFO)
     _logger.info('<<< Analyze Topic: Start >>>')
     make_destination_dir(dest_dir, args.force, _logger)
-    arch.export(dest_dir + '/architecture.yaml', force=True)
     ComponentManager().initialize(args.component_list_json, _logger)
     dict_component_name_topic = create_component_topic_dict(arch)
 

--- a/report/common/utils.py
+++ b/report/common/utils.py
@@ -96,6 +96,7 @@ def create_architecture_from_lttng(func_add_path_to_architecture, args, trace_da
     def _create_architecture_from_lttng(func_add_path_to_architecture, args, trace_data):
         # Note: Unable to use add_path_to_architecture() directly here to avoid circular import
         arch = Architecture('lttng', trace_data)
+        arch.export(args.architecture_file, force=True)
         func_add_path_to_architecture(args, arch)
 
     proc = multiprocessing.Process(target=_create_architecture_from_lttng, args=(func_add_path_to_architecture, args, trace_data))

--- a/report/report_analysis/analyze_all.py
+++ b/report/report_analysis/analyze_all.py
@@ -17,7 +17,6 @@ Script to make analysis reports
 from __future__ import annotations
 import sys
 import os
-from pathlib import Path
 import argparse
 from distutils.util import strtobool
 import logging
@@ -50,6 +49,7 @@ def parse_arg():
 
     # options for add_path
     parser.add_argument('--target_path_json', type=str, default='target_path.json')
+    parser.add_argument('--architecture_file', type=str, default='architecture.yaml')
     parser.add_argument('--architecture_file_path', type=str, default='architecture_path.yaml')
     parser.add_argument('--use_latest_message', action='store_true', default=True)
     parser.add_argument('--max_node_depth', type=int, default=15)
@@ -84,6 +84,9 @@ def main():
     logger.debug(f'sim_time: {args.sim_time}')
     logger.debug(f'is_path_analysis_only: {args.is_path_analysis_only}')
     logger.debug(f'target_path_json: {args.target_path_json}')
+    if not os.path.isabs(args.architecture_file):
+        args.architecture_file = os.path.join(args.dest_dir, args.architecture_file)
+    logger.debug(f'architecture_file: {args.architecture_file}')
     if not os.path.isabs(args.architecture_file_path):
         args.architecture_file_path = os.path.join(args.dest_dir, args.architecture_file_path)
     logger.debug(f'architecture_file_path: {args.architecture_file_path}')
@@ -101,32 +104,34 @@ def main():
     # Create architecture for path analysis
     # 　Run add_path_to_architecture in a subprocess to avoid memory leak from search_paths
     create_architecture_from_lttng(add_path_to_architecture.add_path_to_architecture, args, trace_data)
-    arch = Architecture('yaml', args.architecture_file_path)
+    arch = Architecture('yaml', args.architecture_file)
+    arch_path = Architecture('yaml', args.architecture_file_path)
 
     # Read trace data
     start_strip, end_strip = (0, 0) if args.find_valid_duration else (args.start_strip, args.end_strip )
     lttng = read_trace_data(trace_data, start_strip, end_strip, False)
 
-    app = Application(arch, lttng)
-
     # Find duration to be analyzed
     #  Run path analysis and find start point(sec) where the topic runs in the paths
     if args.find_valid_duration:
-        valid_start, valid_end = find_valid_duration.analyze(args, lttng, arch, app)
+        app_path = Application(arch_path, lttng)
+        valid_start, valid_end = find_valid_duration.analyze(args, lttng, arch_path, app_path)
         args.start_strip = valid_start + args.start_strip
         args.end_strip = valid_end + args.end_strip
         logger.info(f'Find valid duration. start_strip: {args.start_strip}, end_strip: {args.end_strip}')
         logger.info(f'Reload trace data')
         lttng = read_trace_data(trace_data, args.start_strip, args.end_strip, False)
-        app = Application(arch, lttng)
 
     # Analyze
     if os.path.exists(args.dest_dir + '/analyze_path/index.html'):
         logger.info(f'Skip creating path report to save time')
     else:
-        analyze_path.analyze(args, lttng, arch, app, args.dest_dir + '/analyze_path')
+        app_path = Application(arch_path, lttng)
+        analyze_path.analyze(args, lttng, arch_path, app_path, args.dest_dir + '/analyze_path')
+        del app_path
 
     if not args.is_path_analysis_only:
+        app = Application(arch, lttng)
         analyze_node.analyze(args, lttng, arch, app, args.dest_dir + '/analyze_node')
         analyze_topic.analyze(args, lttng, arch, app, args.dest_dir + '/analyze_topic')
 

--- a/report/report_validation/validate_all.py
+++ b/report/report_validation/validate_all.py
@@ -17,11 +17,10 @@ Script to make validation reports
 from __future__ import annotations
 import sys
 import os
-from pathlib import Path
 import argparse
 from distutils.util import strtobool
 import logging
-from caret_analyze import Architecture, Application, Lttng
+from caret_analyze import Architecture, Application
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/..')
 from common.utils import create_architecture_from_lttng, create_logger, read_trace_data
 from validate_topic import generate_expectation_list, validate_topic
@@ -50,6 +49,7 @@ def parse_arg():
 
     # options for add_path
     parser.add_argument('--target_path_json', type=str, default='target_path.json')
+    parser.add_argument('--architecture_file', type=str, default='architecture.yaml')
     parser.add_argument('--architecture_file_path', type=str, default='architecture_path.yaml')
     parser.add_argument('--use_latest_message', action='store_true', default=True)
     parser.add_argument('--max_node_depth', type=int, default=15)
@@ -91,6 +91,9 @@ def main():
     logger.debug(f'sim_time: {args.sim_time}')
     logger.debug(f'is_path_analysis_only: {args.is_path_analysis_only}')
     logger.debug(f'target_path_json: {args.target_path_json}')
+    if not os.path.isabs(args.architecture_file):
+        args.architecture_file = os.path.join(args.dest_dir, args.architecture_file)
+    logger.debug(f'architecture_file: {args.architecture_file}')
     if not os.path.isabs(args.architecture_file_path):
         args.architecture_file_path = os.path.join(args.dest_dir, args.architecture_file_path)
     logger.debug(f'architecture_file_path: {args.architecture_file_path}')
@@ -113,32 +116,34 @@ def main():
     # Create architecture for path analysis
     # 　Run add_path_to_architecture in a subprocess to avoid memory leak from search_paths
     create_architecture_from_lttng(add_path_to_architecture.add_path_to_architecture, args, trace_data)
-    arch = Architecture('yaml', args.architecture_file_path)
+    arch = Architecture('yaml', args.architecture_file)
+    arch_path = Architecture('yaml', args.architecture_file_path)
 
     # Read trace data
     start_strip, end_strip = (0, 0) if args.find_valid_duration else (args.start_strip, args.end_strip )
     lttng = read_trace_data(trace_data, start_strip, end_strip, False)
 
-    app = Application(arch, lttng)
-
     # Find duration to be analyzed
     #  Run path analysis and find start point(sec) where the topic runs in the paths
     if args.find_valid_duration:
-        valid_start, valid_end = find_valid_duration.analyze(args, lttng, arch, app)
+        app_path = Application(arch_path, lttng)
+        valid_start, valid_end = find_valid_duration.analyze(args, lttng, arch_path, app_path)
         args.start_strip = valid_start + args.start_strip
         args.end_strip = valid_end + args.end_strip
         logger.info(f'Find valid duration. start_strip: {args.start_strip}, end_strip: {args.end_strip}')
         logger.info(f'Reload trace data')
         lttng = read_trace_data(trace_data, args.start_strip, args.end_strip, False)
-        app = Application(arch, lttng)
 
     # Analyze and validate
     if os.path.exists(args.dest_dir + '/analyze_path/index.html'):
         logger.info(f'Skip creating path report to save time')
     else:
-        analyze_path.analyze(args, lttng, arch, app, args.dest_dir + '/analyze_path')
+        app_path = Application(arch_path, lttng)
+        analyze_path.analyze(args, lttng, arch_path, app_path, args.dest_dir + '/analyze_path')
+        del app_path
 
     if not args.is_path_analysis_only:
+        app = Application(arch, lttng)
         xaxis_type = 'sim_time' if args.sim_time else 'system_time'
         generate_expectation_list.create_topic_from_callback(args.callback_list_filename, args.report_directory, args.topic_list_filename)
         generate_expectation_list.generate_list(args.verbose, arch, args.report_directory, args.component_list_json, args.topic_list_filename, args.expectation_topic_csv_filename)

--- a/report/validate_callback/validate_callback.py
+++ b/report/validate_callback/validate_callback.py
@@ -430,7 +430,6 @@ def validate(verbose, arch: Architecture, app: Application, dest_dir: str, force
     _logger.info('<<< Validate callback start >>>')
 
     make_destination_dir(dest_dir + '/validate_callback', force, _logger)
-    arch.export(dest_dir + '/architecture.yaml', force=True)
     ComponentManager().initialize(component_list_json, _logger)
 
     for component_name, _ in ComponentManager().component_dict.items():


### PR DESCRIPTION
## Background

In [this PR,](https://github.com/tier4/caret_report/pull/206) duplicate callbacks (subscription callbacks for the same topic) are removed within `add_path_to_architecture`, keeping only the latest one. However, the `arch` produced there was being used for **all** analyses, including node analysis.

As a result, when a node legitimately subscribes to the same topic at multiple points, all callbacks except the latest are removed from `arch`, making them unavailable for analysis — even though all of them should be analyzed. Which causes CI failure: https://github.com/tier4/caret_report/actions/runs/24789741397

At the same time, when duplicate callbacks exist, the previous code (before [this PR,](https://github.com/tier4/caret_report/pull/206) ) causes only the first generated path to pass `verify()`; all other paths return `False` and cannot be analyzed.

Both concerns must be addressed together.

<img width="2440" height="1983" alt="image" src="https://github.com/user-attachments/assets/b4fc990c-f11b-4de4-8ff4-09de4649bdeb" />


## Changes

- **Path analysis** uses the `arch` introduced in [this PR](https://github.com/tier4/caret_report/pull/206), where all but the latest duplicate callbacks are removed.
- **All other analyses** (e.g., node analysis) use the original `arch` without any callback removal.
- **Other minor fixes**:
  - Remove redundant `architecture.yaml` exports scattered across modules.
  - Continue analysis instead of exiting when `path.verify()` fails.
  - Add error handling for empty DataFrames.

## Tests

- `Tests with Autoware` passed except for the difference in `architecture.yaml`

```
sh ../compare/compare.sh 
[compare] ========== Result ==========
[compare] 1/3 file existence matches
[compare] OK. file existence matches
[compare] 2/3 yaml files
[compare] OK. yaml matches
[compare] 3/3 PNG files
[compare] OK. PNG matches
[compare] ====== ALL OK ==============
```

- Path analysis for the trace data which contains duplicated callbacks succeed

<img width="1362" height="1269" alt="image" src="https://github.com/user-attachments/assets/a16fca5f-aa3c-4a11-afb2-273e195d6ded" />



