### PR TITLE
ci: fix TestWithAutoware

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,9 @@ RUN git clone https://github.com/tier4/caret.git ros2_caret_ws && \
 RUN cd ros2_caret_ws/src/CARET/caret_analyze && \
     git show --format='%H' --no-patch
 
+# hadolint ignore=DL3013
+RUN pip3 install --no-cache-dir 'matplotlib>=3.7'
+
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,9 @@ RUN git clone https://github.com/tier4/caret.git ros2_caret_ws && \
 RUN cd ros2_caret_ws/src/CARET/caret_analyze && \
     git show --format='%H' --no-patch
 
+# Workaround for ROS Humble: osrf/ros:humble-desktop installs matplotlib 3.5.1 via apt,
+# which is compiled against numpy 1.x and incompatible with numpy 2.x (pulled in by caret_analyze).
+# Override with a pip version that supports numpy 2.x.
 # hadolint ignore=DL3013
 RUN pip3 install --no-cache-dir 'matplotlib>=3.7'
 


### PR DESCRIPTION
## Summary

The scheduled CI workflow ["Test with Autoware"](https://github.com/tier4/caret_report/actions/runs/25121166023) has been consistently failing since April 29, 2026 at the **"Compare report contents"** step.

---

### Observed Error

The "Compare report contents" step fails with:

```
[compare] 1/3 file existence matches
Only in reference_result: analyze_node
Only in reference_result: analyze_path
Only in reference_result: analyze_topic
Only in reference_result: architecture.yaml
Only in reference_result: architecture_path.yaml
Only in reference_result: index.html
[ERROR][compare] ERROR. file existence doesn't match
```

These files are missing because the "Create CARET report" step exits in ~2 seconds without producing any output (it should take ~10 minutes).

---

### Investigation

#### The "Create CARET report" step silently fails

Although the step is marked as **success**, the following fatal errors occur inside the Docker container:

```
A module that was compiled using NumPy 1.x cannot be run in NumPy 2.2.6 as it may crash.
...
AttributeError: _ARRAY_API not found        ← 1st attempt at matplotlib._path
...
ImportError: numpy.core.multiarray failed to import  ← 2nd attempt, fatal
```

These errors prevent `analyze_all.py` from importing its dependencies, so no output files are generated. `make_report.sh` exits with a non-zero code due to `set -e`, but `entrypoint.sh` does not check this exit code, so the Docker container exits with code 0 and the step appears successful.

#### Comparing the two runs

Both runs used the same code (`08d46ed`), same base image (`osrf/ros:humble-desktop`, last pushed April 16), and same apt packages. The only difference in pip packages was:

| Package | April 24 (success) | April 29 (failure) |
|---|---|---|
| colorcet | **3.1.0** | **3.2.1** |
| numpy | 2.2.6 | 2.2.6 |
| matplotlib | 3.5.1 | 3.5.1 |

`colorcet 3.2.0` and `3.2.1` were released on **April 28, 2026** — one day before the first failure.

---

### Root Cause

#### colorcet 3.2.x changed how matplotlib is imported

[PR #133 "Add Type Hints to core module"](https://github.com/holoviz/colorcet/pull/133) in holoviz/colorcet introduced a new `_dependencies.py` file, changing the matplotlib import pattern:

**colorcet 3.1.0** (`__init__.py`):
```python
try:
    from matplotlib.colors import LinearSegmentedColormap, ListedColormap
    ...
except ImportError:
    # fallback stubs
```

**colorcet 3.2.1** (`_dependencies.py`):
```python
if find_spec("matplotlib") or TYPE_CHECKING:
    import matplotlib as mpl          # full import, unconditional
    from matplotlib.colors import LinearSegmentedColormap, ListedColormap, ...
```

#### Why this breaks the analysis

The Docker image has an inherent incompatibility:
- `numpy 2.2.6` (pip)
- `matplotlib 3.5.1` (system apt package, compiled against numpy 1.x)

`matplotlib._path` is a C extension compiled against numpy 1.x and is incompatible with numpy 2.x. In colorcet 3.2.1, `import matplotlib as mpl` triggers a full matplotlib initialization chain:

```
import matplotlib as mpl
  → matplotlib.__init__ → matplotlib.rcsetup → matplotlib.colors
    → matplotlib.scale → matplotlib.ticker → matplotlib.transforms
      → matplotlib._path  ← numpy 1.x compiled C extension
          AttributeError: _ARRAY_API not found   (1st attempt)
```

After this first failure, `matplotlib._path` is left in a broken state in Python's import cache. When the same import chain is triggered again within the same process (via `from caret_analyze.plot import Plot` in `analyze_node.py`), a different and fatal error is raised:

```
ImportError: numpy.core.multiarray failed to import   (2nd attempt, fatal)
```

This causes `from analyze_node import analyze_node` (line 26 of `analyze_all.py`) to fail completely.

#### Why April 24 succeeded

In colorcet 3.1.0, matplotlib was imported as `from matplotlib.colors import LinearSegmentedColormap`. This narrower import path also triggers `matplotlib._path`, but the resulting `AttributeError` is absorbed differently — the double-import failure sequence that produces the fatal `ImportError` is not triggered, so matplotlib loads in a degraded-but-functional mode and the analysis proceeds.

---

### Fix

Replace the system apt `matplotlib 3.5.1` (compiled against numpy 1.x) with a pip-installed version compatible with numpy 2.x by adding the following to `docker/Dockerfile`:

```dockerfile
# hadolint ignore=DL3013
RUN pip3 install --no-cache-dir 'matplotlib>=3.7'
```

This overrides the apt-installed `matplotlib 3.5.1` with a version compiled against numpy 2.x, resolving the `_ARRAY_API` incompatibility for `matplotlib._path` and all downstream packages (`numexpr`, `bottleneck`) that print compatibility warnings.


## Tests

https://github.com/tier4/caret_report/actions/runs/25150340151
